### PR TITLE
Adds JS module to support (very) simple, string based templating

### DIFF
--- a/Assets/src/js/modules/Template.js
+++ b/Assets/src/js/modules/Template.js
@@ -1,0 +1,43 @@
+/*global require, module, $ */
+'use strict';
+
+function Template(templateString, options) {
+
+	options = options || {};
+	this.settings = $.extend({
+		tokenPrefix: '%',
+		tokenSuffix: '%',
+		regexpModifiers: 'gi'
+	}, options);
+
+	this.templateString = templateString;
+}
+
+Template.prototype = Object.create({
+	buildRegExp: function buildRegExp(token) {
+		return new RegExp(this.settings.tokenPrefix + token + this.settings.tokenSuffix, this.settings.regexpModifiers);
+	},
+	replaceToken: function replaceToken(token, value, template) {
+		var pattern = this.buildRegExp(token);
+
+		template = template || this.templateString;
+		return template.replace(pattern, value);
+	},
+	populate: function populate(hash) {
+		var populated = this.template;
+		var self = this;
+
+		$.each(hash, function(token, value) {
+			populated = self.replaceToken(token, value, populated);
+		});
+
+		return populated;
+	}
+		
+});
+
+module.exports = {
+	createTemplate: function createTemplate(templateString, options) {
+		return new Template(templateString, options);
+	}
+}


### PR DESCRIPTION
Module contains a constructor for a Template object, and exposes a method to get back a new Template object.

I've not added any requires for the module since it should be optional.

example usage:

```javascript
var createTemplate = require('./modules/Template.js').createTemplate;
var templateFooBar = createTemplate('Replace this %foo% with %bar%');

console.log(templateFooBar.populate({foo: 'bar', bar: 'foo'}));
```
