### PR TITLE
License info in package.json

### DIFF
--- a/Assets/src/package.json
+++ b/Assets/src/package.json
@@ -3,6 +3,7 @@
 	"version": "2.0.0",
 	"description": "A scalable, modular front-end framework for the modern web.",
 	"repository": "https://github.com/connectivedx/Phoenix",
+	"license": "MIT",
 	"devDependencies": {
 		"merge-stream": "~0.1.6",
 		"vinyl-source-stream": "~1.0.0",

--- a/Assets/src/sassdoc-theme/package.json
+++ b/Assets/src/sassdoc-theme/package.json
@@ -4,6 +4,7 @@
   "title": "Phoenix Default Theme",
   "author": "Connective DX",
   "version": "1.0.0",
+  "license": "MIT",
   "keywords": [
     "sassdoc-theme"
   ],


### PR DESCRIPTION
Adds licensing info to both Phoenix's `package.json` and the Phoenix SassDoc theme `package.json` (both MIT). There is a license included in both projects already, this merely makes it explicit to npm, stopping both the command line ~~nagging~~ warning on builds and adheres to best practice.