### PR TITLE
Adds .editorconfig

### DIFF
--- a/Assets/src/.editorconfig
+++ b/Assets/src/.editorconfig
@@ -1,0 +1,10 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Adds basic formatting settings for IDEs that recognize the `.editorconfig` file:

* utf-8 chartacter set
* 4-character-wide tabs (not spaces)
* trim trailing whitespace
* insert new line at end of files

This is becoming an established standard for OS projects. There are editorconfig plugins available for or support is baked into Coda, Sublime Text, Visual Studio, Vim, and most other popular editors. See http://editorconfig.org for details.