### PR TITLE
Disable SSL validation prior to npm install

### DIFF
--- a/Assets/src/build/build.cmd
+++ b/Assets/src/build/build.cmd
@@ -51,6 +51,7 @@ if %errorlevel% neq 0 (
 :npm_install
 REM don't ask why you need to cmd /c this, but if you don't the script exits thereafter without running gulp!
 echo Running npm install
+cmd /c "npm set strict-ssl false"
 cmd /c "npm install"
 if %errorlevel% neq 0 (
 	echo npm install exited with code %errorlevel%


### PR DESCRIPTION
When attempting a build for a client, behind their corporate firewall, I received an error message similar to ```Error: UNABLE_TO_VERIFY_LEAF_SIGNATURE```.

To get around this, I disabled SSL validation to keep the npm install running without error.

Open to any feedback if this isn't considered best practice. Got me past my deployment issue however.

