### PR TITLE
Removes column-config @extend inside column mixin

### DIFF
--- a/Assets/src/css/mixins/grid/_semantic-grid.scss
+++ b/Assets/src/css/mixins/grid/_semantic-grid.scss
@@ -72,8 +72,11 @@
 	$centered: map-get($options, centered);
 	$includeGutterWidth: map-get($options, includeGutterWidth);
 
+	float: $defaultFloat;
+	margin: 0;
+	min-height: 1px;
+
 	@if $centered == true {
-		@extend %column-config;
 		clear: both;
 		margin-left: centered($columns, $options);
 		margin-top: 0;
@@ -85,7 +88,6 @@
 		}
 	}
 	@else {
-		@extend %column-config;
 		padding: $padding;
 		margin-top: 0;
 		width: columns($columns, $options);


### PR DESCRIPTION
Helps to avoid newly stricter LibSass errors from popping up and DRYs out the mixin a bit.

Fixes #193.