### PR TITLE
Release 2.3.0

### DIFF
--- a/Assets/src/build/drivers/css.js
+++ b/Assets/src/build/drivers/css.js
@@ -2,13 +2,14 @@
 /*global console */
 'use strict';
 
-var base64 = require('gulp-base64'),
-	cssmin = require('gulp-minify-css'),
-	gulpif = require('gulp-if'),
-	prefix = require('gulp-autoprefixer'),
-	sass = require('gulp-sass'),
-	sassdoc = require('sassdoc'),
-	sourcemaps = require('gulp-sourcemaps');
+var	 base64 = require('gulp-base64'),
+		cssmin = require('gulp-minify-css'),
+		gulpif = require('gulp-if'),
+		sass = require('gulp-sass'),
+		postcss = require('gulp-postcss'),
+		prefix = require('autoprefixer'),
+		sourcemaps = require('gulp-sourcemaps'),
+		sassdoc = require('sassdoc');
 
 var cssDriver = {
 	build: function(pipeline, debug) {
@@ -31,13 +32,12 @@ var cssDriver = {
 				theme: "./sassdoc-theme"
 			})))
 			.pipe(sass())
-			.pipe(prefix({
-				browsers: ['last 2 versions', 'IE >= 9', 'Android >= 4']
-			}))
+			.pipe(postcss([ prefix({
+				browsers: ['last 2 versions', 'IE >= 9', 'Android >= 4'] })
+			]))
 			.pipe(gulpif(debug, sourcemaps.write('./')))
 			.pipe(base64({
-				exclude: [/\icomoon/],
-				extensions: ['svg']
+				exclude: [/\icomoon/]
 			}))
 			.pipe(gulpif(!debug, cssmin({
 				advanced: false

--- a/Assets/src/package.json
+++ b/Assets/src/package.json
@@ -1,41 +1,44 @@
 {
-	"name": "Phoenix",
-	"version": "2.2.4",
-	"description": "A scalable, modular front-end framework for the modern web.",
-	"repository": "https://github.com/connectivedx/Phoenix",
-	"license": "MIT",
-	"devDependencies": {
-		"merge-stream": "~0.1.6",
-		"vinyl-source-stream": "~1.0.0",
-		"glob": "~4.4.1",
-		"rimraf": "~2.2.8",
-		"multimatch": "^2.0.0",
-		"through2": "^0.6.3",
-		"del": "~1.1.1",
-
-		"gulp": "~3.9.0",
-
-		"gulp-filter": "~2.0.2",
-		"gulp-ignore": "~1.2.1",
-		"gulp-if": "~1.2.5",
-		"gulp-util": "~3.0.4",
-		"gulp-buffer": "~0.0.2",
-		"gulp-rev-all": "~0.7.6",
-		"gulp-plumber": "~0.6.6",
-		"gulp-livereload": "~3.8.0",
-
-		"gulp-sass": "^2.2.0",
-		"sassdoc": "~2.1.8",
-		"gulp-sourcemaps": "~1.5.2",
-		"gulp-base64": "~0.1.3",
-		"gulp-autoprefixer": "~3.0.2",
-		"gulp-minify-css": "~1.2.1",
-
-		"browserify": "~9.0.6",
-		"gulp-uglify": "~1.1.0",
-
-		"gulp-imagemin": "~2.2.1",
-
-		"jquery": "~2.1.3"
-	}
+  "name": "Phoenix",
+  "version": "2.3.0",
+  "description": "A scalable, modular front-end framework for the modern web.",
+  "repository": {
+	  "type": "git",
+	  "url": "https://github.com/connectivedx/Phoenix"
+  },
+ "author": "Connective DX",
+  "bugs": {
+	"url": "https://github.com/connectivedx/Phoenix/issues"
+  },
+  "homepage": "https://github.com/connectivedx/Phoenix#readme",
+  "license": "MIT",
+  "devDependencies": {
+	"autoprefixer": "^6.4.0",
+	"browserify": "~9.0.6",
+	"del": "~1.1.1",
+	"glob": "~4.4.1",
+	"gulp": "~3.9.0",
+	"gulp-base64": "~0.1.3",
+	"gulp-buffer": "~0.0.2",
+	"gulp-filter": "~2.0.2",
+	"gulp-if": "~1.2.5",
+	"gulp-ignore": "~1.2.1",
+	"gulp-imagemin": "~2.2.1",
+	"gulp-livereload": "~3.8.0",
+	"gulp-minify-css": "~1.2.1",
+	"gulp-plumber": "~0.6.6",
+	"gulp-postcss": "^6.1.1",
+	"gulp-rev-all": "~0.7.6",
+	"gulp-sass": "^2.2.0",
+	"gulp-sourcemaps": "~1.5.2",
+	"gulp-uglify": "~1.1.0",
+	"gulp-util": "~3.0.4",
+	"jquery": "~2.1.3",
+	"merge-stream": "~0.1.6",
+	"multimatch": "^2.0.0",
+	"rimraf": "~2.2.8",
+	"sassdoc": "~2.1.8",
+	"through2": "^0.6.3",
+	"vinyl-source-stream": "~1.0.0"
+  }
 }


### PR DESCRIPTION
* replaces `gulp-autoprefixer` with a `gulp-postcss` + `autoprefixer` task (fixes #196)
* updates `package.json` to include more valuable info
* removes Base64 of SVGs as part of the CSS build, [as Base64 SVGs are frequently larger than straight SVG includes](https://css-tricks.com/probably-dont-base64-svg/)
* bumps version to 2.3.0