### PR TITLE
Release 2.3.0

### DIFF
--- a/Assets/src/package.json
+++ b/Assets/src/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Phoenix",
-	"version": "2.2.3",
+	"version": "2.2.4",
 	"description": "A scalable, modular front-end framework for the modern web.",
 	"repository": "https://github.com/connectivedx/Phoenix",
 	"license": "MIT",


### PR DESCRIPTION
* replaces `gulp-autoprefixer` with a `gulp-postcss` + `autoprefixer` task (fixes #196)
* updates `package.json` to include more valuable info
* removes Base64 of SVGs as part of the CSS build, [as Base64 SVGs are frequently larger than straight SVG includes](https://css-tricks.com/probably-dont-base64-svg/)
* bumps version to 2.3.0